### PR TITLE
aarch64 stage2: move fork save-area to Entry 2 (fix nested-fork hang)

### DIFF
--- a/builder-hex0-aarch64-stage2.S
+++ b/builder-hex0-aarch64-stage2.S
@@ -28,7 +28,15 @@
 ;   0x60820000  File descriptors (512KB, 32768 x 16 bytes)
 ;   0x7B800000  Kernel stack top (grows down)
 ;   0x42000000  Preload buffer (8MB, raspi3b only, PA 0x02000000 slow zone)
-;   0x78000000  Saved process memory (bump allocator)
+;   Saved process memory (bump allocator) -- BOARD-SPECIFIC base, because the
+;   upper VA window maps to different PA on each board (see paging notes below):
+;     virt    VA 0x80000000 (Entry 2 -> PA 0x80000000): ~540MB up to file data
+;             at 0xA1900000, clear of the kernel stack at 0x7B800000. A single
+;             fork saves a whole process image (tens of MB), so it must NOT
+;             sit in Entry 1 below the kernel stack (that capped it at 56MB).
+;     raspi3b VA 0x78000000 (Entry 1 -> PA 0x38000000): valid in the 1GB RAM.
+;             0x80000000 is UNSAFE here -- raspi3b's Entry 2 aliases PA
+;             0x00000000, so it would overwrite the kernel in low RAM.
 ;   0xA1900000  File data (bump allocator, grows up to 0xBFFFFFFF)
 ;
 ; AArch64 paging (1GB block descriptors, level 1 table):
@@ -4198,7 +4206,22 @@ storage_ready:
     mov x10, #1
     str x10, [x9, #0x20]
 
-    movz x10, #0x7800, lsl #16   ; save area at VA 0x78000000 (PA 0x38000000)
+    ; Saved-process-memory bump allocator base. Board-specific: the two boards
+    ; map the upper VA window to different physical RAM.
+    ;   virt    Entry 2: VA 0x80000000 -> PA 0x80000000 (upper RAM); ~540MB up
+    ;           to file data (0xA1900000), clear of the kernel stack -- a single
+    ;           fork saves a whole process image (tens of MB).
+    ;   raspi3b Entry 2: VA 0x80000000 -> PA 0x00000000 (aliases low RAM, would
+    ;           clobber the kernel). Keep the legacy VA 0x78000000 (Entry 1 ->
+    ;           PA 0x38000000), valid in the 1GB RAM.
+    ; x27 = board id from _trampoline (3 = raspi3b, 0 = virt).
+    cmp x27, #3
+    b.eq save_area_raspi3b
+    movz x10, #0x8000, lsl #16   ; virt: VA 0x80000000
+    b save_area_set
+save_area_raspi3b:
+    movz x10, #0x7800, lsl #16   ; raspi3b: VA 0x78000000 (-> PA 0x38000000)
+save_area_set:
     str x10, [x9, #0x28]
 
     ; board_has_sdhci is set by init_sdhci or cleared by init_virtio — not touched here

--- a/builder-hex0-aarch64-stage2.hex0
+++ b/builder-hex0-aarch64-stage2.hex0
@@ -28,7 +28,15 @@
 ;   0x60820000  File descriptors (512KB, 32768 x 16 bytes)
 ;   0x7B800000  Kernel stack top (grows down)
 ;   0x42000000  Preload buffer (8MB, raspi3b only, PA 0x02000000 slow zone)
-;   0x78000000  Saved process memory (bump allocator)
+;   Saved process memory (bump allocator) -- BOARD-SPECIFIC base, because the
+;   upper VA window maps to different PA on each board (see paging notes below):
+;     virt    VA 0x80000000 (Entry 2 -> PA 0x80000000): ~540MB up to file data
+;             at 0xA1900000, clear of the kernel stack at 0x7B800000. A single
+;             fork saves a whole process image (tens of MB), so it must NOT
+;             sit in Entry 1 below the kernel stack (that capped it at 56MB).
+;     raspi3b VA 0x78000000 (Entry 1 -> PA 0x38000000): valid in the 1GB RAM.
+;             0x80000000 is UNSAFE here -- raspi3b's Entry 2 aliases PA
+;             0x00000000, so it would overwrite the kernel in low RAM.
 ;   0xA1900000  File data (bump allocator, grows up to 0xBFFFFFFF)
 ;
 ; AArch64 paging (1GB block descriptors, level 1 table):
@@ -4198,7 +4206,22 @@ df fc ff 97  # bl spi_sd_init
 2a 00 80 d2  # mov x10, #1
 2a 11 00 f9  # str x10, [x9, #0x20]
 
-0a 00 af d2  # movz x10, #0x7800, lsl #16 # save area at VA 0x78000000 (PA 0x38000000)
+    ; Saved-process-memory bump allocator base. Board-specific: the two boards
+    ; map the upper VA window to different physical RAM.
+    ;   virt    Entry 2: VA 0x80000000 -> PA 0x80000000 (upper RAM); ~540MB up
+    ;           to file data (0xA1900000), clear of the kernel stack -- a single
+    ;           fork saves a whole process image (tens of MB).
+    ;   raspi3b Entry 2: VA 0x80000000 -> PA 0x00000000 (aliases low RAM, would
+    ;           clobber the kernel). Keep the legacy VA 0x78000000 (Entry 1 ->
+    ;           PA 0x38000000), valid in the 1GB RAM.
+    ; x27 = board id from _trampoline (3 = raspi3b, 0 = virt).
+7f 0f 00 f1  # cmp x27, #3
+60 00 00 54  # b.eq save_area_raspi3b
+0a 00 b0 d2  # movz x10, #0x8000, lsl #16 # virt: VA 0x80000000
+02 00 00 14  # b save_area_set
+#:save_area_raspi3b
+0a 00 af d2  # movz x10, #0x7800, lsl #16 # raspi3b: VA 0x78000000 (-> PA 0x38000000)
+#:save_area_set
 2a 15 00 f9  # str x10, [x9, #0x28]
 
     ; board_has_sdhci is set by init_sdhci or cleared by init_virtio — not touched here
@@ -4220,17 +4243,17 @@ df fc ff 97  # bl spi_sd_init
     ; Zero process descriptors (64KB at 0x60400000)
 00 08 ac d2  # movz x0, #0x6040, lsl #16
 01 02 80 d2  # movz x1, #0x10, lsl #12
-b6 f9 ff 97  # bl memset_zero
+b2 f9 ff 97  # bl memset_zero
 
     ; Zero file names area (16MB at 0x60900000)
 00 12 ac d2  # movz x0, #0x6090, lsl #16
 01 20 a0 d2  # movz x1, #0x100, lsl #16
-b3 f9 ff 97  # bl memset_zero
+af f9 ff 97  # bl memset_zero
 
     ; Zero file descriptors area (512KB at 0x60820000)
 40 10 ac d2  # movz x0, #0x6082, lsl #16
 01 01 a0 d2  # movz x1, #0x8, lsl #16
-b0 f9 ff 97  # bl memset_zero
+ac f9 ff 97  # bl memset_zero
 
     ; Set process 0 current_dir = "/"
 09 08 ac d2  # movz x9, #0x6040, lsl #16
@@ -4247,7 +4270,7 @@ ea 05 80 d2  # mov w10, #0x2F
     ; Set up page table (skip on raspi3b — trampoline already did it)
 7f 0f 00 f1  # cmp x27, #3
 00 01 00 54  # b.eq skip_page_table
-e6 f9 ff 97  # bl setup_page_table
+e2 f9 ff 97  # bl setup_page_table
     ; Enable MMU (stays on forever) — preserve RES1 bits
 09 10 38 d5  # mrs x9, sctlr_el1
 29 01 40 b2  # orr x9, x9, #1
@@ -4262,4 +4285,4 @@ df 3f 03 d5  # isb
 #:sdhci_reinit_done
 
     ; Jump to internal shell
-f9 fc ff 17  # b internalshell
+f5 fc ff 17  # b internalshell

--- a/builder-hex0-aarch64-stage2.hex2
+++ b/builder-hex0-aarch64-stage2.hex2
@@ -28,7 +28,15 @@
 ;   0x60820000  File descriptors (512KB, 32768 x 16 bytes)
 ;   0x7B800000  Kernel stack top (grows down)
 ;   0x42000000  Preload buffer (8MB, raspi3b only, PA 0x02000000 slow zone)
-;   0x78000000  Saved process memory (bump allocator)
+;   Saved process memory (bump allocator) -- BOARD-SPECIFIC base, because the
+;   upper VA window maps to different PA on each board (see paging notes below):
+;     virt    VA 0x80000000 (Entry 2 -> PA 0x80000000): ~540MB up to file data
+;             at 0xA1900000, clear of the kernel stack at 0x7B800000. A single
+;             fork saves a whole process image (tens of MB), so it must NOT
+;             sit in Entry 1 below the kernel stack (that capped it at 56MB).
+;     raspi3b VA 0x78000000 (Entry 1 -> PA 0x38000000): valid in the 1GB RAM.
+;             0x80000000 is UNSAFE here -- raspi3b's Entry 2 aliases PA
+;             0x00000000, so it would overwrite the kernel in low RAM.
 ;   0xA1900000  File data (bump allocator, grows up to 0xBFFFFFFF)
 ;
 ; AArch64 paging (1GB block descriptors, level 1 table):
@@ -4198,7 +4206,22 @@ DFFCFF97  # bl spi_sd_init
 2A0080D2  # mov x10, #1
 2A1100F9  # str x10, [x9, #0x20]
 
-0A00AFD2  # movz x10, #0x7800, lsl #16 # save area at VA 0x78000000 (PA 0x38000000)
+    ; Saved-process-memory bump allocator base. Board-specific: the two boards
+    ; map the upper VA window to different physical RAM.
+    ;   virt    Entry 2: VA 0x80000000 -> PA 0x80000000 (upper RAM); ~540MB up
+    ;           to file data (0xA1900000), clear of the kernel stack -- a single
+    ;           fork saves a whole process image (tens of MB).
+    ;   raspi3b Entry 2: VA 0x80000000 -> PA 0x00000000 (aliases low RAM, would
+    ;           clobber the kernel). Keep the legacy VA 0x78000000 (Entry 1 ->
+    ;           PA 0x38000000), valid in the 1GB RAM.
+    ; x27 = board id from _trampoline (3 = raspi3b, 0 = virt).
+7F0F00F1  # cmp x27, #3
+60000054  # b.eq save_area_raspi3b
+0A00B0D2  # movz x10, #0x8000, lsl #16 # virt: VA 0x80000000
+02000014  # b save_area_set
+:save_area_raspi3b
+0A00AFD2  # movz x10, #0x7800, lsl #16 # raspi3b: VA 0x78000000 (-> PA 0x38000000)
+:save_area_set
 2A1500F9  # str x10, [x9, #0x28]
 
     ; board_has_sdhci is set by init_sdhci or cleared by init_virtio — not touched here
@@ -4220,17 +4243,17 @@ DFFCFF97  # bl spi_sd_init
     ; Zero process descriptors (64KB at 0x60400000)
 0008ACD2  # movz x0, #0x6040, lsl #16
 010280D2  # movz x1, #0x10, lsl #12
-B6F9FF97  # bl memset_zero
+B2F9FF97  # bl memset_zero
 
     ; Zero file names area (16MB at 0x60900000)
 0012ACD2  # movz x0, #0x6090, lsl #16
 0120A0D2  # movz x1, #0x100, lsl #16
-B3F9FF97  # bl memset_zero
+AFF9FF97  # bl memset_zero
 
     ; Zero file descriptors area (512KB at 0x60820000)
 4010ACD2  # movz x0, #0x6082, lsl #16
 0101A0D2  # movz x1, #0x8, lsl #16
-B0F9FF97  # bl memset_zero
+ACF9FF97  # bl memset_zero
 
     ; Set process 0 current_dir = "/"
 0908ACD2  # movz x9, #0x6040, lsl #16
@@ -4247,7 +4270,7 @@ EA0580D2  # mov w10, #0x2F
     ; Set up page table (skip on raspi3b — trampoline already did it)
 7F0F00F1  # cmp x27, #3
 00010054  # b.eq skip_page_table
-E6F9FF97  # bl setup_page_table
+E2F9FF97  # bl setup_page_table
     ; Enable MMU (stays on forever) — preserve RES1 bits
 091038D5  # mrs x9, sctlr_el1
 290140B2  # orr x9, x9, #1
@@ -4262,4 +4285,4 @@ DF3F03D5  # isb
 :sdhci_reinit_done
 
     ; Jump to internal shell
-F9FCFF17  # b internalshell
+F5FCFF17  # b internalshell


### PR DESCRIPTION
The fork-emulation save area (a bump allocator that memcpy's the parent's whole process image plus its kernel and user stacks on every clone) was initialized at VA 0x78000000 -- inside paging Entry 1, growing up toward the kernel-stack top at 0x7B800000. That gave it only ~56MB AND backed it directly onto the live, descending kernel stack.

A process with a heap of tens of MB therefore overran the save area into the kernel stack on its first fork, corrupting return addresses -> silent hang (a CPU fault would have printed "!EC:..." and exited 139 instead). hs hit this running its probe sweep (hs forks+execs hs; its startup heap is ~55MB), where riscv64 -- whose save area is 576MB and separate from the kernel stack -- did not. The header comment already documented the intended Entry-2 layout ("saved process mem at 0xB0000000"); the code just shipped the wrong base.

Relocate the save area to VA 0x80000000 (Entry 2, identity-mapped): ~540MB up to file data at 0xA1900000, clear of the kernel stack. One constant.